### PR TITLE
Fix verify error when passing an ArrayBuffer

### DIFF
--- a/src/rsa.android.ts
+++ b/src/rsa.android.ts
@@ -85,12 +85,15 @@ export class Rsa {
             return new Uint8Array(sign).buffer;
         }
     }
-    verify(signature: string, data: string, key: RsaKey, alg: RsaHashAlgorithm): boolean {
+    verify(signature: string | ArrayBuffer, data: string, key: RsaKey, alg: RsaHashAlgorithm): boolean {
         const signEngine = Signature.getInstance(getProviderName(alg));
         let publicKey = key.valueOf().getPublic()
         signEngine.initVerify(publicKey);
         signEngine.update(stringToByteArray(data));
-        let signatureBytes = android.util.Base64.decode(signature, android.util.Base64.DEFAULT);
+        const signatureBytes = typeof signature === 'string'
+            ? android.util.Base64.decode(signature, android.util.Base64.DEFAULT)
+            : Array.from(new Uint8Array(signature));
+
         return signEngine.verify(signatureBytes);
     }
 }


### PR DESCRIPTION
In the index definition, the verify method can get an ArrayBuffer but when its passed, the application crashes.

This fix applies just for Android.