### PR TITLE
Fix app crash when trying to load an undefined key

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -9,7 +9,7 @@ export declare class Rsa {
   importPublicKey(tag: string, key: string): RsaKey;
   importPrivateKey(tag: string, key: string): RsaKey;
   removeKeyFromKeychain(tag: string): void;
-  loadKey(tag: string): RsaKey;
+  loadKey(tag: string): RsaKey | null;
   generateKey(tag: string, keySize: number, permanent?: boolean): RsaKey;
   sign(data: string, key: RsaKey, alg: RsaHashAlgorithm): ArrayBuffer
   sign(data: string, key: RsaKey, alg: RsaHashAlgorithm, returnAsBase64: false): ArrayBuffer;

--- a/src/rsa.android.ts
+++ b/src/rsa.android.ts
@@ -32,10 +32,15 @@ export class Rsa {
         let pubKey = kf.generatePublic(spec);
         return new RsaKey(new java.security.KeyPair(pubKey, null));
     }
-    loadKey(tag: string): RsaKey {
+    loadKey(tag: string): RsaKey | null {
         const keyStore = java.security.KeyStore.getInstance("AndroidKeyStore");
         keyStore.load(null);
         let entry = keyStore.getEntry(tag, null) as java.security.KeyStore.PrivateKeyEntry;
+
+        if (!entry) {
+            return null;
+        }
+
         let privKey = entry.getPrivateKey();
         let cert = entry.getCertificate();
         let pubKey = cert.getPublicKey();


### PR DESCRIPTION
This commit aims to fix an application crash when trying to load a nonexistent key.

This fix applies just for Android.